### PR TITLE
prevent multiple snitches from running

### DIFF
--- a/app/workers/sidekiq/snitch.rb
+++ b/app/workers/sidekiq/snitch.rb
@@ -12,8 +12,9 @@ module Sidekiq
       if ENV['SIDEKIQ_SNITCH_URL'].present?
         Net::HTTP.get(URI(ENV['SIDEKIQ_SNITCH_URL']))
 
+        already_scheduled = Sidekiq::ScheduledSet.new.any? {|job| job.klass == "Sidekiq::Snitch" }
         # groundhog day!
-        Snitch.perform_in(1.hour)
+        Snitch.perform_in(1.hour) unless already_scheduled
       end
     end
   end


### PR DESCRIPTION
This change checks for already scheduled snitches before scheduling a new one, so if more than 1 snitch is running, they will be pruned down to 1.  To be more effective we could introduce a random delay incase multiple snitches were scheduled for the exact same time, but it seems to be working just fine for us as is.